### PR TITLE
Upgrade dependencies and migrate to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bevy = { version = "0.14", default-features = false, features = [
 
 [package.metadata.release]
 pre-release-replacements = [
-  {search="\\| 0.13 \\| [0-9.]* \\|",replace="| 0.13 | {{version}} |",file="Readme.md"},
+  {search="\\| 0.14 \\| [0-9.]* \\|",replace="| 0.14 | {{version}} |",file="Readme.md"},
   {search="bevy-debug-text-overlay = \\{ version = \"[0-9.]*\"",replace="bevy-debug-text-overlay = { version = \"{{version}}\"",file="Readme.md"},
   {search="bevy-debug-text-overlay = \"[0-9.]*\"",replace="bevy-debug-text-overlay = \"{{version}}\"",file="Readme.md"},
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "Readme.md"
 keywords = ["bevy", "debug", "overlay", "message"]
 categories = ["game-development", "development-tools"]
 repository = "https://github.com/nicopap/bevy-debug-text-overlay"
-version = "8.1.0"
+version = "14.0.0"
 edition = "2021"
 
 [features]
@@ -15,13 +15,12 @@ default = ["debug"]
 debug = ["bevy/bevy_render", "bevy/bevy_asset", "bevy/bevy_ui", "bevy/bevy_text", "bevy/bevy_core_pipeline", "bevy/default_font"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
+bevy = { version = "0.14", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
   "bevy_render", "x11", "bevy_core_pipeline", "bevy_asset", "bevy_sprite"
 ] }
-# bevy-inspector-egui = { version = "0.8" }
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ println-debugger, you will love this crate when working with bevy!
 
 ```toml
 [dependencies]
-bevy-debug-text-overlay = "8.1.0"
+bevy-debug-text-overlay = "14.0.0"
 ```
 
 This bevy plugin is fairly trivial to use. You must:
@@ -55,7 +55,7 @@ fn screen_print_text(time: Res<Time>) {
     let x = (13, 3.4, vec![1,2,3,4,5,6,7,8]);
     if at_interval(0.1) {
         let last_fps = 1.0 / time.delta_seconds();
-        screen_print!(col: Color::CYAN, "fps: {last_fps:.0}");
+        screen_print!(col: Color::AQUA, "fps: {last_fps:.0}");
         screen_print!("current time: {current_time:.2}")
     }
     if at_interval(2.0) {
@@ -92,7 +92,7 @@ debug = ["bevy-debug-text-overlay/debug"]
 default = ["debug"]
 
 # Manually specify features for bevy-debug-text-overlay (omitting "debug")
-bevy-debug-text-overlay = { version = "8.1.0", default-features = false }
+bevy-debug-text-overlay = { version = "14.0.0", default-features = false }
 ```
 
 Now when making your release build, you should use
@@ -141,11 +141,16 @@ I'm welcoming contributions if you have any fixes:
     invoked with the crate path
   * Do not panic on exceeding 4096 prints per frame, instead log an error
   * Use the std `OnceLock` over `lazy_static!`
+* `14.0.0`:
+  * **Breaking**: bump bevy version to `0.14`
+  * `screen_print!` now accepts `Into<Color>` in compliance with `bevy 0.14` changes
+
 
 ### Version matrix
 
 | bevy | latest supporting version      |
 |------|--------|
+| 0.14 | 14.0.0 |
 | 0.13 | 8.1.0 |
 | 0.12 | 7.0.0 |
 | 0.11 | 6.0.0 |

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,5 +1,6 @@
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_debug_text_overlay::{screen_print, OverlayPlugin};
+use bevy::color::palettes::css;
 
 fn main() {
     App::new()
@@ -39,13 +40,13 @@ fn screen_print_text(time: Res<Time>) {
     };
     if at_interval(3.123) {
         let colors = [
-            Color::RED,
-            Color::ORANGE,
-            Color::YELLOW,
-            Color::GREEN,
-            Color::CYAN,
-            Color::BLUE,
-            Color::VIOLET,
+            css::RED,
+            css::ORANGE,
+            css::YELLOW,
+            css::GREEN,
+            css::AQUA,
+            css::BLUE,
+            css::VIOLET,
         ];
         for (i, color) in colors.iter().enumerate() {
             screen_print!(push, sec: 1.9384, col: *color, "seven messages each 3 seconds: {i}");
@@ -62,11 +63,11 @@ fn screen_print_text(time: Res<Time>) {
     }
     mut_show.field_1 = 34.34234;
     if at_interval(12.934) {
-        let col = Color::RED;
+        let col = css::RED;
         screen_print!(col: col, "every 13: {}, {:?}", show.field_2, show.field_3)
     }
     if at_interval(4.832) {
-        let col = Color::PINK;
+        let col = css::PINK;
         screen_print!(sec: 3.2123, col: col, "every 30: {mut_show:?}");
     }
     if at_interval(0.13243) {
@@ -90,8 +91,8 @@ fn show_fps(time: Res<Time>, mut deltas: Local<Vec<f32>>, mut ring_ptr: Local<us
     if at_interval(2.0) {
         let fps = deltas.len() as f32 / deltas.iter().sum::<f32>();
         let last_fps = 1.0 / time.delta_seconds();
-        screen_print!(col: Color::GREEN, "fps: {fps:.0}");
-        screen_print!(col: Color::CYAN, "last: {last_fps:.0}");
+        screen_print!(col: css::GREEN, "fps: {fps:.0}");
+        screen_print!(col: css::AQUA, "last: {last_fps:.0}");
     }
 }
 
@@ -112,7 +113,7 @@ fn show_cursor_position(
             let window_size = Vec2::new(window.width(), window.height());
             let ndc = (screen_pos / window_size) * 2.0 - Vec2::ONE;
             let ndc_to_world =
-                camera_transform.compute_matrix() * camera.projection_matrix().inverse();
+                camera_transform.compute_matrix() * camera.clip_from_view().inverse();
             let world_pos = ndc_to_world.project_point3(ndc.extend(-1.0));
             let world_pos: Vec2 = world_pos.truncate();
 

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -31,6 +31,7 @@ use std::fmt;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{Mutex, OnceLock};
 
+use bevy::color::palettes::css;
 use bevy::{prelude::*, utils::HashMap};
 
 use crate::block::Blocks;
@@ -107,13 +108,13 @@ macro_rules! screen_print {
         $crate::screen_print!(@impl push, sec: $timeout, col: None, $text $(, $fmt_args)*);
     };
     (sec: $timeout:expr, $text:expr $(, $fmt_args:expr)*) => {
-        $crate::screen_print!(@impl sec: $timeout, col: None, $text $(, $fmt_args)*);
+        $crate::screen_print!(@impl sec: $timeout, col: Option::<Srgba>::None, $text $(, $fmt_args)*);
     };
     (push, $text:expr $(, $fmt_args:expr)*) => {
-        $crate::screen_print!(@impl push, sec: 7.0, col: None, $text $(, $fmt_args)*);
+        $crate::screen_print!(@impl push, sec: 7.0, col: Option::<Srgba>::None, $text $(, $fmt_args)*);
     };
     ($text:expr $(, $fmt_args:expr)*) => {
-        $crate::screen_print!(@impl sec: 7.0, col: None, $text $(, $fmt_args)*);
+        $crate::screen_print!(@impl sec: 7.0, col: Option::<Srgba>::None, $text $(, $fmt_args)*);
     };
     (@impl sec: $timeout:expr, col: $color:expr, $text:expr $(, $fmt_args:expr)*) => {{
         use $crate::{InvocationSiteKey, command_channels};
@@ -174,8 +175,9 @@ impl CommandChannels {
         key: InvocationSiteKey,
         text: impl FnOnce() -> String,
         timeout: f64,
-        color: Option<Color>,
+        color: Option<impl Into<Color>>,
     ) {
+        let color = color.map(|c| c.into());
         let text = format!("{key} {}\n", text());
         let cmd = Command::Refresh { text, key, color, timeout };
         let sent = self.sender.try_send(cmd).is_ok();
@@ -188,8 +190,9 @@ impl CommandChannels {
         key: InvocationSiteKey,
         text: impl FnOnce() -> String,
         timeout: f64,
-        color: Option<Color>,
+        color: Option<impl Into<Color>>,
     ) {
+        let color = color.map(|c| c.into());
         let text = format!("{key} {}\n", text());
         let cmd = Command::Push { text, color, timeout };
         let sent = self.sender.try_send(cmd).is_ok();
@@ -345,7 +348,7 @@ pub struct OverlayPlugin {
 }
 impl Default for OverlayPlugin {
     fn default() -> Self {
-        Self { fallback_color: Color::YELLOW, font_size: 13.0 }
+        Self { fallback_color: css::YELLOW.into(), font_size: 13.0 }
     }
 }
 


### PR DESCRIPTION
This was a quick fix for my project.

I've also changed the versioning approach to (somewhat) match Bevy's (making the crate version 14.0.0). This is extremely optional, but will help people know if the current version of the crate is compatible with their version of Bevy from now on, making migration easier.

Most certainly open for comments
![image](https://github.com/user-attachments/assets/5960abe3-f0da-4caf-9665-e43e56ca3ad9)
